### PR TITLE
patch: keyboard-conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ Type `cmd+shift+p` or `cmd+shift+p` for open the command pallete. All the comman
 ### Keyboard shortcuts
 
 - Add new file or folder - `ctrl+shift+a` - macOS `cmd+shift+a`
-- Copy file name - `ctrl+f ctrl+n` - macOS `cmd+f cmd+n`
-- Copy file path - `ctrl+c ctrl+f` - macOS `cmd+c cmd+f`
-- Copy relative file path - `ctrl+c ctrl+r` - macOS `cmd+c cmd+r`
-- Delete/Remove file or folder - `ctrl+r ctrl+m` - macOS `cmd+r cmd+m`
-- Duplicate file or folder - `ctrl+d ctrl+d` - macOS `cmd+d cmd+d`
-- Rename file - `ctrl+r ctrl+r` - macOS `cmd+r cmd+r`
+- Copy file name - `ctrl+alt+f ctrl+alt+n` - macOS `alt+cmd+f alt+cmd+n`
+- Copy file path - `ctrl+alt+c ctrl+alt+f` - macOS `alt+cmd+c alt+cmd+f`
+- Copy relative file path - `alt+cmd+c alt+cmd+f` - macOS `alt+cmd+c alt+cmd+r`
+- Delete/Remove file or folder - `ctrl+alt+r ctrl+alt+m` - macOS `alt+cmd+r alt+cmd+m`
+- Duplicate file or folder - `ctrl+alt+d ctrl+alt+d` - macOS `alt+cmd+d alt+cmd+d`
+- Rename file - `ctrl+alt+r ctrl+alt+r` - macOS `alt+cmd+r alt+cmd+r`
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -141,44 +141,44 @@
         "command": "fileExtraAdd.execute"
       },
       {
-        "key": "ctrl+f ctrl+n",
-        "linux": "ctrl+f ctrl+n",
-        "mac": "cmd+f cmd+n",
+        "key": "ctrl+alt+f ctrl+alt+n",
+        "linux": "ctrl+alt+f ctrl+alt+n",
+        "mac": "alt+cmd+f alt+cmd+n",
         "when": "editorTextFocus",
         "command": "fileExtraCopyFileName.execute"
       },
       {
-        "key": "ctrl+c ctrl+f",
-        "linux": "ctrl+c ctrl+f",
-        "mac": "cmd+c cmd+f",
+        "key": "ctrl+alt+c ctrl+alt+f",
+        "linux": "ctrl+alt+c ctrl+alt+f",
+        "mac": "alt+cmd+c alt+cmd+f",
         "when": "editorTextFocus",
         "command": "fileExtraCopyFilePath.execute"
       },
       {
-        "key": "ctrl+c ctrl+r",
-        "linux": "ctrl+c ctrl+r",
-        "mac": "cmd+c cmd+r",
+        "key": "ctrl+alt+c ctrl+alt+r",
+        "linux": "ctrl+alt+c ctrl+alt+r",
+        "mac": "alt+cmd+c alt+cmd+r",
         "when": "editorTextFocus",
         "command": "fileExtraCopyRelativeFilePath.execute"
       },
       {
-        "key": "ctrl+r ctrl+m",
-        "linux": "ctrl+r ctrl+m",
-        "mac": "cmd+r cmd+m",
+        "key": "ctrl+alt+r ctrl+alt+m",
+        "linux": "ctrl+alt+r ctrl+alt+m",
+        "mac": "alt+cmd+r alt+cmd+m",
         "when": "editorTextFocus",
         "command": "fileExtraRemove.execute"
       },
       {
-        "key": "ctrl+d ctrl+d",
-        "linux": "ctrl+d ctrl+d",
-        "mac": "cmd+d cmd+d",
+        "key": "ctrl+alt+d ctrl+alt+d",
+        "linux": "ctrl+alt+d ctrl+alt+d",
+        "mac": "alt+cmd+d alt+cmd+d",
         "when": "editorTextFocus",
         "command": "fileExtraDuplicate.execute"
       },
       {
-        "key": "ctrl+r ctrl+r",
-        "linux": "ctrl+r ctrl+r",
-        "mac": "cmd+r cmd+r",
+        "key": "ctrl+alt+r ctrl+alt+r",
+        "linux": "ctrl+alt+r ctrl+alt+r",
+        "mac": "alt+cmd+r alt+cmd+r",
         "when": "editorTextFocus",
         "command": "fileExtraRename.execute"
       }


### PR DESCRIPTION
Hey, @willmendesneto some shortcuts had conflicts, mainly shortcuts with combos. 

For example:
**`ctrl+c ctrl+f`**

Some users were no longer able to copy lines, search within a file and etc ...

Just added another key to the `alt` combo, in case the only change is:

Example:
Linux and Windows: **`ctrl+alt+c ctrl+alt+f`**
Mac: **`alt+cmd+c alt+cmd+f`**